### PR TITLE
Stub out rough interfaces for modules

### DIFF
--- a/pokedb/__init__.py
+++ b/pokedb/__init__.py
@@ -1,0 +1,85 @@
+import signal
+import socket
+
+from pokedb import access, locks, logs, storage, transactions
+
+
+def start_socket():
+    s = socket.socket()
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.close()
+    s = socket.socket()
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(('localhost', 1188))
+    s.listen(2)
+    return s
+
+
+def start_pokedb():
+    storage.start()
+    locks.start()
+    transactions.start()
+    access.start()
+    return start_socket()
+
+
+def terminate_pokedb(socket):
+    storage.stop()
+    socket.close()
+
+
+def process_request(data):
+    if data.startswith('wyd'):
+        return transactions._transaction_manager.transaction_statuses
+    elif data.startswith('BEGIN TRANSACTION'):
+        return transactions.begin_transaction()
+    elif data.startswith('COMMIT'):
+        txn_id = int(data.split()[1])
+        return transactions.commit(txn_id)
+    elif data.startswith('ROLLBACK'):
+        txn_id = int(data.split()[1])
+        return transactions.rollback(txn_id)
+    elif data.startswith('TRANSACTION'):
+        words = data.split()
+        txn_id = int(words[1])
+        if not txn_id in transactions._transaction_manager.transactions:
+            return "txn %s does not exist yet" % txn_id
+        operation = words[2]
+        row_id = int(words[3])
+
+        if operation == 'READ':
+            return access.read(txn_id, row_id)
+        elif operation == 'WRITE':
+            value = words[4]
+            return access.write(txn_id, row_id, value)
+
+
+class Killer(object):
+    kill_now = False
+    def __init__(self):
+        signal.signal(signal.SIGINT, self.exit_gracefully)
+        signal.signal(signal.SIGTERM, self.exit_gracefully)
+
+    def exit_gracefully(self, signum, frame):
+        self.kill_now = True
+
+
+if __name__ == '__main__':
+    killer = Killer()
+    s = start_pokedb()
+
+    while True:
+        if killer.kill_now:
+            terminate_pokedb()
+            break
+
+        conn, addr = s.accept()
+        data = conn.recv(1024)
+
+        try:
+            response = str(process_request(data))
+        except ValueError as e:
+            response = e.message
+
+        conn.sendall(response)
+        conn.close()

--- a/pokedb/access/__init__.py
+++ b/pokedb/access/__init__.py
@@ -1,0 +1,5 @@
+"""
+API from main process:
+`get`
+`put`
+"""

--- a/pokedb/access/__init__.py
+++ b/pokedb/access/__init__.py
@@ -3,3 +3,50 @@ API from main process:
 `get`
 `put`
 """
+
+# from pokedb.access.btree import build
+
+# _btree = build_btree()
+
+from pokedb import locks
+from pokedb.locks.exceptions import LockException
+
+
+# I AM A VISITOR HERE I AM NOT PERMANENT
+_storage = dict()
+_temp = dict()
+
+def start():
+    """Load btree"""
+    pass
+
+
+def start_txn(txn_id):
+    _temp[txn_id] = dict()
+
+def read(txn_id, row_id):
+    try:
+        locks.get_locks_for_read(txn_id, 'main', [row_id])
+    except LockException:
+        return "Lock collision for read"
+    else:
+        data = dict()
+        data[row_id] = _storage.get(row_id, None)
+        updated_value = _temp[txn_id].get(row_id, None)
+        if updated_value:
+            data[row_id] = updated_value
+        return data
+
+def write(txn_id, row_id, value):
+    try:
+        locks.get_locks_for_write(txn_id, 'main', [row_id])
+    except LockException:
+        return "Lock collision for write"
+    else:
+        _temp[txn_id][row_id] = value
+        return 'ok'
+
+
+def finish_write(txn_id):
+    for row_id, value in _temp[txn_id].iteritems():
+        _storage[row_id] = value

--- a/pokedb/locks/__init__.py
+++ b/pokedb/locks/__init__.py
@@ -28,30 +28,30 @@ def start():
     _lock_manager = LockManager()
 
 
-def acquire_lock(txn, table, row):
+def acquire_lock(txn_id, table, row):
     """Acquire a row-level lock on a particular row in a particular table for a particular transaction.
 
     raises a LockException if the lock has been taken out by another transaction.
     """
-    return _lock_manager.acquire_lock(txn, table, row)
+    return _lock_manager.acquire_lock(txn_id, table, row)
 
 
-def release_lock(txn, table, row):
+def release_lock(txn_id, table, row):
     """Release a row-level lock.
 
     raises a LockException if the transaction does not own the lock or if the lock has already been released.
     """
-    return _lock_manager.release_lock(txn, table, row)
+    return _lock_manager.release_lock(txn_id, table, row)
 
 
-def release_locks_for_txn(txn):
+def release_locks_for_txn(txn_id):
     """Release all locks held by a particular transaction"""
-    return _lock_manager.release_locks_for_txn(txn)
+    return _lock_manager.release_locks_for_txn(txn_id)
 
 
-def get_locks_for_read(txn, table, rows):
-    return _lock_manager.get_locks_for_read(txn, table, rows)
+def get_locks_for_read(txn_id, table, rows):
+    _lock_manager.get_locks_for_read(txn_id, table, rows)
 
 
-def get_locks_for_write(txn, table, rows):
-    return _lock_manager.get_locks_for_write(txn, table, rows)
+def get_locks_for_write(txn_id, table, rows):
+    _lock_manager.get_locks_for_write(txn_id, table, rows)

--- a/pokedb/locks/__init__.py
+++ b/pokedb/locks/__init__.py
@@ -1,21 +1,57 @@
 """
 API:
-`get_read_locks`
-`get_write_locks`
+`acquire_lock`
+`release_lock`
+`get_locks_for_read`
+`get_locks_for_write`
 `release_locks_for_txn`
 """
 
-
-import os
-
-from pokedb.locks.isolation import read_committed
+from pokedb.locks.exceptions import LockException
+from pokedb.locks.manager import LockManager
 
 
-ISOLATION_RULES = {
-    'READ_COMMITTED': read_committed
-}
+__all__ = [
+    'acquire_lock',
+    'release_lock',
+    'release_locks_for_txn',
+    'get_locks_for_read',
+    'get_locks_for_write',
+]
 
-ISOLATION_LEVEL = os.getenv('ISOLATION_LEVEL', 'READ_COMMITTED')
 
-get_read_locks = ISOLATION_RULES[ISOLATION_LEVEL].get_read_locks
-get_write_locks = ISOLATION_RULES[ISOLATION_LEVEL].get_write_locks
+_lock_manager = None
+
+
+def start():
+    global _lock_manager
+    _lock_manager = LockManager()
+
+
+def acquire_lock(txn, table, row):
+    """Acquire a row-level lock on a particular row in a particular table for a particular transaction.
+
+    raises a LockException if the lock has been taken out by another transaction.
+    """
+    return _lock_manager.acquire_lock(txn, table, row)
+
+
+def release_lock(txn, table, row):
+    """Release a row-level lock.
+
+    raises a LockException if the transaction does not own the lock or if the lock has already been released.
+    """
+    return _lock_manager.release_lock(txn, table, row)
+
+
+def release_locks_for_txn(txn):
+    """Release all locks held by a particular transaction"""
+    return _lock_manager.release_locks_for_txn(txn)
+
+
+def get_locks_for_read(txn, table, rows):
+    return _lock_manager.get_locks_for_read(txn, table, rows)
+
+
+def get_locks_for_write(txn, table, rows):
+    return _lock_manager.get_locks_for_write(txn, table, rows)

--- a/pokedb/locks/__init__.py
+++ b/pokedb/locks/__init__.py
@@ -1,3 +1,11 @@
+"""
+API:
+`get_read_locks`
+`get_write_locks`
+`release_locks_for_txn`
+"""
+
+
 import os
 
 from pokedb.locks.isolation import read_committed

--- a/pokedb/locks/isolation/__init__.py
+++ b/pokedb/locks/isolation/__init__.py
@@ -1,0 +1,13 @@
+import os
+
+from pokedb.locks.isolation import read_committed
+
+ISOLATION_RULES = {
+    'READ_COMMITTED': read_committed
+}
+
+ISOLATION_LEVEL = os.getenv('ISOLATION_LEVEL', 'READ_COMMITTED')
+
+get_read_locks = ISOLATION_RULES[ISOLATION_LEVEL].get_read_locks
+get_write_locks = ISOLATION_RULES[ISOLATION_LEVEL].get_write_locks
+

--- a/pokedb/locks/isolation/read_committed.py
+++ b/pokedb/locks/isolation/read_committed.py
@@ -1,7 +1,7 @@
-def get_read_locks(transaction, rows, lock_manager):
+def get_read_locks(transaction, table, rows, lock_manager):
     return
 
 
-def get_write_locks(transaction, rows, lock_manager):
+def get_write_locks(transaction, table, rows, lock_manager):
     for row in rows:
-        lock_manager.acquire_lock(transaction.id, 'main', row)
+        lock_manager.acquire_lock(transaction.id, table, row)

--- a/pokedb/locks/isolation/read_committed.py
+++ b/pokedb/locks/isolation/read_committed.py
@@ -1,7 +1,7 @@
-def get_read_locks(transaction, table, rows, lock_manager):
+def get_read_locks(transaction_id, table, rows, lock_manager):
     return
 
 
-def get_write_locks(transaction, table, rows, lock_manager):
+def get_write_locks(transaction_id, table, rows, lock_manager):
     for row in rows:
-        lock_manager.acquire_lock(transaction.id, table, row)
+        lock_manager.acquire_lock(transaction_id, table, row)

--- a/pokedb/locks/manager.py
+++ b/pokedb/locks/manager.py
@@ -10,36 +10,36 @@ class LockManager(object):
     def _get_lock_key(self, table, row):
         return "{table}.{row}".format(table=table, row=row)
 
-    def acquire_lock(self, txn, table, row):
+    def acquire_lock(self, txn_id, table, row):
         lock_key = self._get_lock_key(table, row)
         lock_value = self.locks.get(lock_key)
         if not lock_value:
-            self.locks[lock_key] = txn.id
+            self.locks[lock_key] = txn_id
             return
-        elif lock_value and lock_value == txn.id:
+        elif lock_value and lock_value == txn_id:
             return
         else:
             raise LockException('lock already taken out')
 
-    def release_lock(self, txn, table, row):
+    def release_lock(self, txn_id, table, row):
         lock_key = self._get_lock_key(table, row)
         lock_value = self.locks.get(lock_key)
         if not lock_value:
             raise LockException('lock does not exist')
 
-        elif lock_value and lock_value != txn.id:
+        elif lock_value and lock_value != txn_id:
             raise LockException('txn does not own this lock')
 
         else:
             del self.locks[lock_key]
 
-    def release_locks_for_txn(self, txn):
-        lock_keys = [k for k, v in self.locks.iteritems() if v == txn.id]
+    def release_locks_for_txn(self, txn_id):
+        lock_keys = [k for k, v in self.locks.iteritems() if v == txn_id]
         for lock_key in lock_keys:
             del self.locks[lock_key]
 
-    def get_locks_for_read(self, txn, table, rows):
-        return get_read_locks(txn, table, rows, self)
+    def get_locks_for_read(self, txn_id, table, rows):
+        return get_read_locks(txn_id, table, rows, self)
 
-    def get_locks_for_write(self, txn, table, rows):
-        return get_write_locks(txn, table, rows, self)
+    def get_locks_for_write(self, txn_id, table, rows):
+        return get_write_locks(txn_id, table, rows, self)

--- a/pokedb/locks/manager.py
+++ b/pokedb/locks/manager.py
@@ -1,4 +1,5 @@
 from pokedb.locks.exceptions import LockException
+from pokedb.locks.isolation import get_read_locks, get_write_locks
 
 
 class LockManager(object):
@@ -6,33 +7,39 @@ class LockManager(object):
     def __init__(self):
         self.locks = dict()
 
-    def get_lock_key(self, table, row):
+    def _get_lock_key(self, table, row):
         return "{table}.{row}".format(table=table, row=row)
 
-    def acquire_lock(self, txn_id, table, row):
-        lock_key = self.get_lock_key(table, row)
+    def acquire_lock(self, txn, table, row):
+        lock_key = self._get_lock_key(table, row)
         lock_value = self.locks.get(lock_key)
         if not lock_value:
-            self.locks[lock_key] = txn_id
+            self.locks[lock_key] = txn.id
             return
-        elif lock_value and lock_value == txn_id:
+        elif lock_value and lock_value == txn.id:
             return
         else:
             raise LockException('lock already taken out')
 
-    def release_lock(self, txn_id, table, row):
-        lock_key = self.get_lock_key(table, row)
+    def release_lock(self, txn, table, row):
+        lock_key = self._get_lock_key(table, row)
         lock_value = self.locks.get(lock_key)
         if not lock_value:
             raise LockException('lock does not exist')
 
-        elif lock_value and lock_value != txn_id:
+        elif lock_value and lock_value != txn.id:
             raise LockException('txn does not own this lock')
 
         else:
             del self.locks[lock_key]
 
-    def release_locks_for_txn(self, txn_id):
-        lock_keys = [k for k, v in self.locks.iteritems() if v == txn_id]
+    def release_locks_for_txn(self, txn):
+        lock_keys = [k for k, v in self.locks.iteritems() if v == txn.id]
         for lock_key in lock_keys:
             del self.locks[lock_key]
+
+    def get_locks_for_read(self, txn, table, rows):
+        return get_read_locks(txn, table, rows, self)
+
+    def get_locks_for_write(self, txn, table, rows):
+        return get_write_locks(txn, table, rows, self)

--- a/pokedb/logs/__init__.py
+++ b/pokedb/logs/__init__.py
@@ -5,3 +5,8 @@ API:
 import os
 
 LOGFILE = os.getenv('LOGFILE', 'poke.log')
+
+
+def log(something):
+    with open(LOGFILE, 'w') as logfile:
+        logfile.write(something)

--- a/pokedb/logs/__init__.py
+++ b/pokedb/logs/__init__.py
@@ -1,0 +1,7 @@
+"""
+API:
+`log`
+"""
+import os
+
+LOGFILE = os.getenv('LOGFILE', 'poke.log')

--- a/pokedb/storage/__init__.py
+++ b/pokedb/storage/__init__.py
@@ -4,3 +4,37 @@ API to access layer:
 `write`
 `sync`
 """
+
+import os
+
+from pokedb.storage.pager import Pager
+
+
+DBFILE = os.getenv('DBFILE', 'test.db')
+
+_pager = None
+
+
+def start():
+    global _pager
+    _pager = Pager(DBFILE)
+
+
+def get_row(row_id, page_num):
+    page = _pager.get_page(page_num)
+    return page  # notttttt at all what it should be
+
+
+def write_row(row_id, data, page_num):
+    page = _pager.get_page(page_num)
+    return page  # NOPE
+
+
+def sync(page_num):
+    _pager.flush_page(page_num)
+    return page_num
+
+
+def stop():
+    if _pager:
+        return _pager.db_close()

--- a/pokedb/storage/__init__.py
+++ b/pokedb/storage/__init__.py
@@ -1,0 +1,6 @@
+"""
+API to access layer:
+`get`
+`write`
+`sync`
+"""

--- a/pokedb/storage/pager/__init__.py
+++ b/pokedb/storage/pager/__init__.py
@@ -1,0 +1,1 @@
+from pokedb.storage.pager.pager import Pager

--- a/pokedb/transactions/__init__.py
+++ b/pokedb/transactions/__init__.py
@@ -1,0 +1,6 @@
+"""
+From main process, three methods: `begin_transaction`, `commit`, `rollback`
+"""
+
+
+from pokedb.transactions.manager import Transaction, TransactionManager

--- a/pokedb/transactions/__init__.py
+++ b/pokedb/transactions/__init__.py
@@ -2,5 +2,38 @@
 From main process, three methods: `begin_transaction`, `commit`, `rollback`
 """
 
-
 from pokedb.transactions.manager import Transaction, TransactionManager
+
+
+__all__ = [
+    'begin_transaction',
+    'commit',
+    'rollback',
+]
+
+
+_transaction_manager = None
+
+
+def start():
+    global _transaction_manager
+    _transaction_manager = TransactionManager()
+
+
+def begin_transaction():
+    """Returns a transaction id. should it return a txn object?"""
+    return _transaction_manager.begin_transaction()
+
+
+def commit(txn_id):
+    """Can raise a LockException if it cannot release its locks"""
+    return _transaction_manager.commit(txn_id)
+
+
+def rollback(txn_id):
+    """Can raise a LockException if it cannot release its locks"""
+    return _transaction_manager.rollback(txn_id)
+
+
+def is_done(txn_id):
+    return _transaction_manager.transaction_statuses.get(txn_id, None) == 'done'


### PR DESCRIPTION
I want things that are not in `pokedb/locks`, for example, to acquire a lock by importing `acquire_lock` from `pokedb/locks` and then calling that.

The other modules should have no idea how `acquire_lock` works, just that it's the right API for lock-acquiring. That means the API itself looks a little weird--it instantiates an object that stores state but does not expose that object, and calls methods on that object. I was unsure of whether or not I'd stick with it, but implementing various inter-module calls was really easy so I think the extra bit of complexity in the __init__s are ok.

That BerkeleyDB post has a thorough description of what the APIs between each pair of modules should be and I'm basically following that, with some simplifications.