### PR TITLE
Move in-memory storage hack to storage module

### DIFF
--- a/pokedb/access/__init__.py
+++ b/pokedb/access/__init__.py
@@ -27,7 +27,7 @@ def read(txn_id, row_id):
     except LockException:
         return "Lock collision for read"
     else:
-        data = storage.get_row(txn_id, row_id, 1)
+        data = storage.get_row(txn_id, 'main', row_id, 1)
         return data
 
 
@@ -37,7 +37,7 @@ def write(txn_id, row_id, value):
     except LockException:
         return "Lock collision for write"
     else:
-        storage.write_row(txn_id, row_id, value, 1)
+        storage.write_row(txn_id, 'main', row_id, (value), 1)
         return 'ok'
 
 

--- a/pokedb/access/__init__.py
+++ b/pokedb/access/__init__.py
@@ -37,7 +37,7 @@ def write(txn_id, row_id, value):
     except LockException:
         return "Lock collision for write"
     else:
-        storage.write_row(txn_id, 'main', row_id, (value), 1)
+        storage.write_row(txn_id, 'main', row_id, {'value': value}, 1)
         return 'ok'
 
 

--- a/pokedb/storage/__init__.py
+++ b/pokedb/storage/__init__.py
@@ -8,6 +8,7 @@ API to access layer:
 import os
 
 from pokedb.storage.pager import Pager
+from pokedb.storage.serializer import serialize, deserialize
 
 
 DBFILE = os.getenv('DBFILE', 'test.db')

--- a/pokedb/storage/__init__.py
+++ b/pokedb/storage/__init__.py
@@ -15,19 +15,28 @@ DBFILE = os.getenv('DBFILE', 'test.db')
 _pager = None
 
 
+# In-memory storage
+_storage = dict()
+_temp = dict()
+
+
 def start():
     global _pager
     _pager = Pager(DBFILE)
 
 
-def get_row(row_id, page_num):
-    page = _pager.get_page(page_num)
-    return page  # notttttt at all what it should be
+def get_row(txn_id, row_id, page_num):
+    data = dict()
+    data[row_id] = _storage.get(row_id, None)
+    updated_value =  _temp[txn_id].get(row_id, None)
+    if updated_value:
+        data[row_id] = updated_value
+    return data
 
 
-def write_row(row_id, data, page_num):
-    page = _pager.get_page(page_num)
-    return page  # NOPE
+def write_row(txn_id, row_id, data, page_num):
+    _temp[txn_id][row_id] = value
+    return page_num
 
 
 def sync(page_num):

--- a/pokedb/storage/__init__.py
+++ b/pokedb/storage/__init__.py
@@ -20,7 +20,7 @@ _pager = None
 _storage = dict()
 _temp = dict()
 _table_schema = {
-    'main': ('value'),
+    'main': ('value',),
 }
 
 
@@ -34,9 +34,12 @@ def get_row(txn_id, table, row_id, page_num):
     updated_value =  _temp[txn_id].get(row_id, None)
     if updated_value:
         raw_data = updated_value
-    schema = _table_schema.get(table)
-    data = deserialize(schema, raw_data)
-    return data
+    if raw_data:
+        schema = _table_schema.get(table)
+        data = deserialize(schema, raw_data)
+    else:
+        data = None
+    return {row_id: data}
 
 
 def write_row(txn_id, table, row_id, data, page_num):

--- a/pokedb/storage/__init__.py
+++ b/pokedb/storage/__init__.py
@@ -19,6 +19,9 @@ _pager = None
 # In-memory storage
 _storage = dict()
 _temp = dict()
+_table_schema = {
+    'main': ('value'),
+}
 
 
 def start():
@@ -26,17 +29,20 @@ def start():
     _pager = Pager(DBFILE)
 
 
-def get_row(txn_id, row_id, page_num):
-    data = dict()
-    data[row_id] = _storage.get(row_id, None)
+def get_row(txn_id, table, row_id, page_num):
+    raw_data = _storage.get(row_id, None)
     updated_value =  _temp[txn_id].get(row_id, None)
     if updated_value:
-        data[row_id] = updated_value
+        raw_data = updated_value
+    schema = _table_schema.get(table)
+    data = deserialize(schema, raw_data)
     return data
 
 
-def write_row(txn_id, row_id, data, page_num):
-    _temp[txn_id][row_id] = value
+def write_row(txn_id, table, row_id, data, page_num):
+    schema = _table_schema.get(table)
+    raw_data = serialize(schema, data)
+    _temp[txn_id][row_id] = raw_data
     return page_num
 
 

--- a/pokedb/storage/serializer.py
+++ b/pokedb/storage/serializer.py
@@ -11,6 +11,8 @@ def serialize(schema, deserialized_row):
 
 def deserialize(schema, serialized_row):
     deserialized_row = dict()
+    if len(schema) != len(serialized_row):
+        raise ValueError('data has been serialized weirdly')
     for field_name, field_value in izip(schema, serialized_row):
         deserialized_row[field_name] = field_value
     return deserialized_row

--- a/pokedb/storage/serializer.py
+++ b/pokedb/storage/serializer.py
@@ -11,6 +11,6 @@ def serialize(schema, deserialized_row):
 
 def deserialize(schema, serialized_row):
     deserialized_row = dict()
-    for field_name, field_value in izip(schema, serialized_row)
+    for field_name, field_value in izip(schema, serialized_row):
         deserialized_row[field_name] = field_value
     return deserialized_row

--- a/pokedb/storage/serializer.py
+++ b/pokedb/storage/serializer.py
@@ -1,0 +1,16 @@
+"""Storing rows as tuples. A schema is currently a tuple of field names."""
+from itertools import izip
+
+
+def serialize(schema, deserialized_row):
+    serialized_fields = []
+    for field in schema:
+        serialized_fields.append(deserialized_row[field])
+    return tuple(serialized_fields)
+
+
+def deserialize(schema, serialized_row):
+    deserialized_row = dict()
+    for field_name, field_value in izip(schema, serialized_row)
+        deserialized_row[field_name] = field_value
+    return deserialized_row

--- a/tests/access/test_access.py
+++ b/tests/access/test_access.py
@@ -38,14 +38,16 @@ class TestReadRow(unittest.TestCase):
         self.assertEqual(response, {1: None})
 
     def test_returns_stored_value(self):
-        storage._storage[1] = (['test'])
-        storage._temp[2] = {1: 'updated'}
+        storage.write_row(1, 'main', 1, {'value': 'test'}, 1)
+        storage.write_row(2, 'main', 1, {'value': 'updated'}, 1)
+
         response = access.read(1, 1)
         self.assertEqual(response, {1: {'value': 'test'}})
 
     def test_prefers_transaction_specific_value(self):
-        storage._storage[1] = ('test'),
-        storage._temp[2] = {1: ('updated',)}
+        storage.write_row(1, 'main', 1, {'value': 'test'}, 1)
+        storage.write_row(2, 'main', 1, {'value': 'updated'}, 1)
+
         response = access.read(2, 1)
         self.assertEqual(response, {1: {'value': 'updated'}})
 
@@ -54,6 +56,7 @@ class TestReadRow(unittest.TestCase):
         storage._temp = dict()
 
         locks.stop()
+
 
 class TestWriteRow(unittest.TestCase):
 
@@ -76,13 +79,6 @@ class TestWriteRow(unittest.TestCase):
             response = access.write(1, 1, 'test')
 
         self.assertEqual(response, "Lock collision for write")
-
-    def test_does_not_write_over_main_table(self):
-        storage._storage[1] = ('test',)
-        storage._temp[2] = dict()
-        response = access.write(2, 1, 'updated')
-        self.assertEqual(storage._temp[2][1], ('updated',))
-        self.assertEqual(storage._storage[1], ('test',))
 
     def tearDown(self):
         storage._storage = dict()

--- a/tests/storage/test_serializer.py
+++ b/tests/storage/test_serializer.py
@@ -1,0 +1,52 @@
+import unittest
+
+from pokedb.storage import serializer
+
+
+class TestSerialize(unittest.TestCase):
+
+    def test_raises_if_deserialized_row_is_missing_field(self):
+        schema = ('id', 'name', 'primary type', 'secondary type')
+        deserialized_row = {
+            'id': 1,
+            'name': 'bulbasaur',
+            'secondary type': 'poison',
+        }
+        with self.assertRaises(KeyError):
+            serializer.serialize(schema, deserialized_row)
+
+    def test_returns_fields_in_appropriate_order(self):
+        schema = ('id', 'name', 'primary type', 'secondary type')
+        deserialized_row = {
+            'id': 1,
+            'name': 'bulbasaur',
+            'primary type': 'grass',
+            'secondary type': 'poison',
+        }
+
+        raw_data = serializer.serialize(schema, deserialized_row)
+        self.assertEqual(raw_data, (1, 'bulbasaur', 'grass', 'poison'))
+
+
+class TestDeserialize(unittest.TestCase):
+
+    def test_raises_if_row_serialized_with_incorrect_fields(self):
+        schema = ('id', 'name', 'primary type', 'secondary type')
+        serialized_row = ('bulbasaur', 'poison')
+
+        with self.assertRaises(ValueError):
+            serializer.deserialize(schema, serialized_row)
+
+    def test_returns_fields_in_dictionary_form(self):
+        schema = ('id', 'name', 'primary type', 'secondary type')
+        serialized_row = (16, 'pidgey', 'normal', 'flying')
+
+        data = serializer.deserialize(schema, serialized_row)
+        expected_data = {
+            'id': 16,
+            'name': 'pidgey',
+            'primary type': 'normal',
+            'secondary type': 'flying',
+        }
+
+        self.assertEqual(data, expected_data)

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -1,0 +1,52 @@
+import unittest
+
+from pokedb import storage
+
+
+class TestReadRow(unittest.TestCase):
+
+    def setUp(self):
+        storage._storage = dict()
+        storage._temp = dict()
+        storage._temp[1] = dict()
+        storage._temp[2] = dict()
+
+    def test_returns_none_if_data_does_not_exist(self):
+        response = storage.get_row(1, 'main', 1, 2)
+        self.assertEqual(response, {1: None})
+
+    def test_returns_stored_value(self):
+        storage._storage[1] = ('test',)
+        storage._temp[2] = {1: ('updated',)}
+        response = storage.get_row(1, 'main', 1, 1)
+        self.assertEqual(response, {1: {'value': 'test'}})
+
+    def test_prefers_transaction_specific_value(self):
+        storage._storage[1] = ('test'),
+        storage._temp[2] = {1: ('updated',)}
+        response = storage.get_row(2, 'main', 1, 1)
+        self.assertEqual(response, {1: {'value': 'updated'}})
+
+    def tearDown(self):
+        storage._storage = dict()
+        storage._temp = dict()
+
+
+class TestWriteRow(unittest.TestCase):
+
+    def setUp(self):
+        storage._storage = dict()
+        storage._temp = dict()
+        storage._temp[1] = dict()
+        storage._temp[2] = dict()
+
+    def test_does_not_write_over_main_table(self):
+        storage._storage[1] = ('test',)
+        storage._temp[2] = dict()
+        response = storage.write_row(2, 'main', 1, {'value': 'updated'}, 1)
+        self.assertEqual(storage._temp[2][1], ('updated',))
+        self.assertEqual(storage._storage[1], ('test',))
+
+    def tearDown(self):
+        storage._storage = dict()
+        storage._temp = dict()

--- a/tests/transactions/test_transaction_manager.py
+++ b/tests/transactions/test_transaction_manager.py
@@ -1,7 +1,7 @@
 import unittest
 from mock import patch
 
-from pokedb import access, locks
+from pokedb import access, locks, storage
 from pokedb.locks.exceptions import LockException
 from pokedb.transactions.constants import (
     TXN_IN_PROGRESS,
@@ -40,7 +40,7 @@ class TestBeginTransaction(unittest.TestCase):
     def test_creates_temp_storage_for_txn(self):
         txn_id = self.manager.begin_transaction()
 
-        self.assertEqual(access._temp[txn_id], dict())
+        self.assertEqual(storage._temp[txn_id], dict())
 
 
 class TestCommitTransaction(unittest.TestCase):


### PR DESCRIPTION
I only stuck the in-memory datastores in access bc I wanted to demo; they belong in storage.

I also added a serializer that turns rows from tuples to dictionaries; that'll allow us to take some non-formatted data and turn it into something more human legible that looks relational.